### PR TITLE
Tcp server

### DIFF
--- a/ruffd-core/src/server.rs
+++ b/ruffd-core/src/server.rs
@@ -115,16 +115,15 @@ pub struct TcpServer {
 }
 
 impl TcpServer {
-    pub async fn connect<A: ToSocketAddrs>(addr: A) -> Self {
-        // TODO handle below unwrap
-        let stream = TcpStream::connect(addr).await.unwrap();
+    pub async fn connect<A: ToSocketAddrs>(addr: A) -> std::io::Result<Self> {
+        let stream = TcpStream::connect(addr).await?;
         let stream = Arc::new(Mutex::new(stream));
         let reader = io::BufReader::new(TcpReader {
             inner: stream.clone(),
         });
         let writer = TcpWriter { inner: stream };
         let inner = Service::new(reader, writer);
-        Self { inner }
+        Ok(Self { inner })
     }
     pub fn get_service_mut(&mut self) -> &mut TcpService {
         &mut self.inner

--- a/ruffd-core/src/server.rs
+++ b/ruffd-core/src/server.rs
@@ -1,8 +1,12 @@
 use crate::service::Service;
-use ruffd_types::tokio::io;
+use ruffd_types::tokio::io::{self, AsyncRead, AsyncWrite};
+use ruffd_types::tokio::net::{TcpStream, ToSocketAddrs};
+use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 type StdioService = Service<io::BufReader<io::Stdin>, io::Stdout>;
+type TcpService = Service<io::BufReader<TcpReader>, TcpWriter>;
 
 static STDIO_SERVER_COUNT: AtomicUsize = AtomicUsize::new(0);
 
@@ -20,7 +24,7 @@ impl Default for StdioServer {
     /// Instantiatates a new StdioServer instance
     ///
     /// # Panics
-    /// Panics if more than one StdioServer is stilil visible.
+    /// Panics if more than one StdioServer is still visible.
     /// This is not allowed as there is no way to discriminate  rpc communication
     /// on the same wire
     fn default() -> Self {
@@ -37,6 +41,92 @@ impl Default for StdioServer {
 
 impl StdioServer {
     pub fn get_service_mut(&mut self) -> &mut StdioService {
+        &mut self.inner
+    }
+}
+
+pub struct TcpReader {
+    inner: Arc<Mutex<TcpStream>>,
+}
+
+impl AsyncRead for TcpReader {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+        buf: &mut io::ReadBuf<'_>,
+    ) -> core::task::Poll<std::io::Result<()>> {
+        let mut lock_guard = self.inner.lock().unwrap();
+        let inner = Pin::new(&mut *lock_guard);
+        inner.poll_read(cx, buf)
+    }
+}
+
+pub struct TcpWriter {
+    inner: Arc<Mutex<TcpStream>>,
+}
+
+impl AsyncWrite for TcpWriter {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+        buf: &[u8],
+    ) -> core::task::Poll<std::io::Result<usize>> {
+        let mut lock_guard = self.inner.lock().unwrap();
+        let inner = Pin::new(&mut *lock_guard);
+        inner.poll_write(cx, buf)
+    }
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> core::task::Poll<std::io::Result<()>> {
+        let mut lock_guard = self.inner.lock().unwrap();
+        let inner = Pin::new(&mut *lock_guard);
+        inner.poll_flush(cx)
+    }
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> core::task::Poll<std::io::Result<()>> {
+        let mut lock_guard = self.inner.lock().unwrap();
+        let inner = Pin::new(&mut *lock_guard);
+        inner.poll_shutdown(cx)
+    }
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> core::task::Poll<std::io::Result<usize>> {
+        let mut lock_guard = self.inner.lock().unwrap();
+        let inner = Pin::new(&mut *lock_guard);
+        inner.poll_write_vectored(cx, bufs)
+    }
+    fn is_write_vectored(&self) -> bool {
+        // WARNING: below assumes is_write_vectored for TcpStream to avoid locking
+        true
+    }
+}
+
+/// Slight misnomer in the naming of this struct, this describes a
+/// type capable of producing a service communicating to a client,
+/// over a TcpSocket, however the connection is initialized from this side,
+/// rather than binding to a port and listening, hence behaving more like a client
+pub struct TcpServer {
+    inner: TcpService,
+}
+
+impl TcpServer {
+    pub async fn connect<A: ToSocketAddrs>(addr: A) -> Self {
+        // TODO handle below unwrap
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let stream = Arc::new(Mutex::new(stream));
+        let reader = io::BufReader::new(TcpReader {
+            inner: stream.clone(),
+        });
+        let writer = TcpWriter { inner: stream };
+        let inner = Service::new(reader, writer);
+        Self { inner }
+    }
+    pub fn get_service_mut(&mut self) -> &mut TcpService {
         &mut self.inner
     }
 }


### PR DESCRIPTION
resolves https://github.com/Seamooo/ruffd/issues/4

This PR introduces a Tcp server that can be used to run the lsp service over a tcp connection.

Worthwhile noting that this isn't a tcp server in the traditional sense in terms of accepting connections, it instead initiates the connection to create a TcpStream, usable by `ruffd_core::service::Service`