### PR TITLE
Build server state and associated types from single struct definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,6 +2067,7 @@ dependencies = [
 name = "ruffd-macros"
 version = "0.0.1"
 dependencies = [
+ "convert_case",
  "lsp-types",
  "proc-macro-error",
  "proc-macro2",
@@ -2078,6 +2088,7 @@ dependencies = [
  "lsp-types",
  "rand 0.8.5",
  "ruff",
+ "ruffd-macros",
  "serde",
  "serde_json",
  "thiserror",
@@ -2735,6 +2746,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"

--- a/ruffd-macros/Cargo.toml
+++ b/ruffd-macros/Cargo.toml
@@ -11,6 +11,7 @@ syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro-error = "1.0"
 proc-macro2 = "1.0"
+convert_case = "0.6"
 
 [dev-dependencies]
 ruffd-types = { path = "../ruffd-types" }

--- a/ruffd-macros/src/lib.rs
+++ b/ruffd-macros/src/lib.rs
@@ -1,8 +1,12 @@
+use convert_case::{Case, Casing};
 use proc_macro::{self, TokenStream};
 use proc_macro2::Span;
 use proc_macro_error::{abort, proc_macro_error, Diagnostic, Level};
 use quote::{quote, ToTokens};
-use syn::{parse_macro_input, parse_quote, FnArg, Ident, ItemFn, Pat, PatIdent, PatType, Stmt};
+use syn::{
+    parse_macro_input, parse_quote, Fields, FnArg, GenericParam, Ident, Index, ItemFn, ItemStruct,
+    Pat, PatIdent, PatType, Stmt, Token, Type,
+};
 
 struct FnDetails {
     asyncness: bool,
@@ -235,6 +239,186 @@ pub fn notification(args: TokenStream, stream: TokenStream) -> TokenStream {
         }
         #[allow(unused_imports)]
         use #fn_identifier::#fn_identifier;
+    }
+    .into()
+}
+
+fn wrap_rw_fields(item: &mut ItemStruct) {
+    let fields = match &mut item.fields {
+        Fields::Named(x) => Some(&mut x.named),
+        Fields::Unnamed(x) => Some(&mut x.unnamed),
+        Fields::Unit => None,
+    };
+    if let Some(fields) = fields {
+        for field in fields.iter_mut() {
+            let inner_ty = &field.ty;
+            let new_ty: Type = parse_quote!(::std::sync::Arc<::tokio::sync::RwLock<#inner_ty>>);
+            field.ty = new_ty;
+        }
+    }
+}
+
+fn make_handle_struct(item: &mut ItemStruct) {
+    let ident_prefix = item.ident.to_string();
+    item.ident = Ident::new(&format!("{}Handles", ident_prefix), Span::call_site());
+    let guard_lifetime: GenericParam = parse_quote!('guard);
+    item.generics.params.insert(0, guard_lifetime);
+    item.generics.lt_token = Some(<Token![<]>::default());
+    item.generics.gt_token = Some(<Token![>]>::default());
+    let fields = match &mut item.fields {
+        Fields::Named(x) => Some(&mut x.named),
+        Fields::Unnamed(x) => Some(&mut x.unnamed),
+        Fields::Unit => None,
+    };
+    if let Some(fields) = fields {
+        for field in fields.iter_mut() {
+            let inner_ty = &field.ty;
+            let new_ty: Type = parse_quote!(
+                Option<crate::state::RwGuarded<'guard, #inner_ty>>
+            );
+            field.ty = new_ty;
+        }
+    }
+    item.attrs = vec![];
+}
+
+fn make_lock_req_struct(item: &mut ItemStruct) {
+    let ident_prefix = item.ident.to_string();
+    item.ident = Ident::new(&format!("{}Locks", ident_prefix), Span::call_site());
+    let fields = match &mut item.fields {
+        Fields::Named(x) => Some(&mut x.named),
+        Fields::Unnamed(x) => Some(&mut x.unnamed),
+        Fields::Unit => None,
+    };
+    if let Some(fields) = fields {
+        for field in fields.iter_mut() {
+            let inner_ty = &field.ty;
+            let new_ty: Type = parse_quote!(
+                Option<crate::state::RwReq<#inner_ty>>
+            );
+            field.ty = new_ty;
+        }
+    }
+    item.attrs = vec![parse_quote!(#[derive(Default)])];
+}
+
+fn make_lock_to_handle_func(item: &ItemStruct) -> impl ToTokens {
+    let ident_prefix = item.ident.to_string();
+    let func_ident = Ident::new(
+        format!("{}_handles_from_locks", ident_prefix.to_case(Case::Snake)).as_str(),
+        Span::call_site(),
+    );
+    let locks_ty = Ident::new(format!("{}Locks", ident_prefix).as_str(), Span::call_site());
+    let handles_ty = Ident::new(
+        format!("{}Handles", ident_prefix).as_str(),
+        Span::call_site(),
+    );
+    let (statements, return_expr) = match &item.fields {
+        Fields::Named(fields) => {
+            let variable_idents = fields
+                .named
+                .iter()
+                .map(|field| field.ident.as_ref().unwrap().clone())
+                .collect::<Vec<_>>();
+            let statements = variable_idents
+                .iter()
+                .map(|field_ident| {
+                    quote! {
+                        let #field_ident = match &locks.#field_ident {
+                            Some(x) => Some(x.lock().await),
+                            None => None,
+                        };
+                    }
+                })
+                .collect::<Vec<_>>();
+            let variable_idents_iter = variable_idents.iter();
+            let return_expr = quote! {
+                #handles_ty {
+                    #(#variable_idents_iter),*
+                }
+            };
+            (statements, return_expr)
+        }
+        Fields::Unnamed(fields) => {
+            let variable_idents = fields
+                .unnamed
+                .iter()
+                .enumerate()
+                .map(|(idx, _)| Ident::new(format!("var_{}", idx).as_str(), Span::call_site()))
+                .collect::<Vec<_>>();
+            let statements = variable_idents
+                .iter()
+                .enumerate()
+                .map(|(idx, var_name)| {
+                    let field_idx = Index::from(idx);
+                    quote! {
+                        let #var_name = match &locks.#field_idx {
+                            Some(x) => Some(x.lock().await),
+                            None => None,
+                        };
+                    }
+                })
+                .collect::<Vec<_>>();
+            let variable_idents_iter = variable_idents.iter();
+            let return_expr = quote!(#handles_ty(#(#variable_idents_iter),*));
+            (statements, return_expr)
+        }
+        Fields::Unit => (vec![quote!()], quote!(#handles_ty())),
+    };
+    let statements_iter = statements.iter();
+    quote! {
+        pub async fn #func_ident(locks: &#locks_ty) -> #handles_ty<'_>
+        {
+            #(#statements_iter)*
+            #return_expr
+        }
+    }
+}
+
+/// Transforms an input struct into 3 new structs and a convenience
+/// async function
+///
+/// `<Ident>` will contain the same struct with all fields having
+/// public access and wrapped by `Arc<tokio::sync::RwLock<T>>`
+///
+/// `<Ident>Locks` will contain fields with corresponding identifiers to
+/// the original struct, wrapped with `Option<ruffd_types::state::RwReq<T>>`
+///
+/// `<Ident>Handles` will contain fields with corresponding identifiers to the original struct,
+/// wrapped with `Option<ruffd_types::state::RwGuarded<'guard,T>>`
+///
+/// `<Ident:snake_case>_handles_from_locks` will construct an `<Ident>Handles`
+/// type from a reference to `<Ident>Locks`
+///
+/// # Note
+///
+/// This macro is only for use inside `ruffd_types` as the ruffd_types imports
+/// are aliased with `crate` rather than `::ruffd_types`
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn server_state(_: TokenStream, stream: TokenStream) -> TokenStream {
+    let input_struct = parse_macro_input!(stream as ItemStruct);
+    let lock_wrapped_struct = {
+        let mut rv = input_struct.clone();
+        wrap_rw_fields(&mut rv);
+        rv
+    };
+    let handle_struct = {
+        let mut rv = input_struct.clone();
+        make_handle_struct(&mut rv);
+        rv
+    };
+    let lock_req_struct = {
+        let mut rv = input_struct.clone();
+        make_lock_req_struct(&mut rv);
+        rv
+    };
+    let convenience_func = make_lock_to_handle_func(&input_struct);
+    quote! {
+        #lock_wrapped_struct
+        #handle_struct
+        #lock_req_struct
+        #convenience_func
     }
     .into()
 }

--- a/ruffd-macros/tests/server_state/type_names.rs
+++ b/ruffd-macros/tests/server_state/type_names.rs
@@ -1,0 +1,18 @@
+use ruffd_macros::server_state;
+use ruffd_types::tokio::sync::RwLock;
+use std::sync::Arc;
+
+#[server_state]
+pub struct Foo {
+    pub foo: u32,
+    pub bar: bool,
+}
+
+fn main() {
+    let new_state = Foo {
+        foo: Arc::new(RwLock::new(3)),
+        bar: Arc::new(RwLock::new(false)),
+    };
+    let locks = FooLocks::default();
+    let handles_fut = foo_handles_from_locks(locks);
+}

--- a/ruffd-macros/tests/server_state/type_names.stderr
+++ b/ruffd-macros/tests/server_state/type_names.stderr
@@ -12,5 +12,5 @@ note: function defined here
   --> tests/server_state/type_names.rs:5:1
    |
 5  | #[server_state]
-   | ^^^^^^^^^^^^^^^
+   | -^^^^^^^^^^^^^^
    = note: this error originates in the attribute macro `server_state` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/ruffd-macros/tests/server_state/type_names.stderr
+++ b/ruffd-macros/tests/server_state/type_names.stderr
@@ -1,0 +1,16 @@
+error[E0308]: mismatched types
+  --> tests/server_state/type_names.rs:17:46
+   |
+17 |     let handles_fut = foo_handles_from_locks(locks);
+   |                       ---------------------- ^^^^^
+   |                       |                      |
+   |                       |                      expected `&FooLocks`, found struct `FooLocks`
+   |                       |                      help: consider borrowing here: `&locks`
+   |                       arguments to this function are incorrect
+   |
+note: function defined here
+  --> tests/server_state/type_names.rs:5:1
+   |
+5  | #[server_state]
+   | ^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `server_state` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/ruffd-types/Cargo.toml
+++ b/ruffd-types/Cargo.toml
@@ -11,6 +11,7 @@ serde = "1.0"
 serde_json = "1.0"
 thiserror = "1.0"
 anyhow = "1.0"
+ruffd-macros = { path = "../ruffd-macros" }
 
 [dev-dependencies]
 bencher = "0.1"

--- a/ruffd-types/src/state.rs
+++ b/ruffd-types/src/state.rs
@@ -159,7 +159,7 @@ impl DocumentBuffer {
     }
 }
 
-#[server_state]
+#[server_state(in_ruffd_types = true)]
 pub struct ServerState {
     pub project_root: Option<lsp_types::Url>,
     pub open_buffers: HashMap<lsp_types::Url, DocumentBuffer>,


### PR DESCRIPTION
This PR introduces the `server_state` macro used to build types to assert correct scheduling for such that side effects occur in-order, whilst enabling concurrent execution. These types include fields with respective read / write locks, A type providing information on which locks should be acquired by a request, and list of optional lock guards to contain the locks themselves. Due to the tightly coupled nature of producing these handles, a utility function is also provided by this macro