### PR TITLE
updated macro tests for rustc 1.65

### DIFF
--- a/ruffd-macros/tests/server_state/type_names.stderr
+++ b/ruffd-macros/tests/server_state/type_names.stderr
@@ -12,5 +12,5 @@ note: function defined here
   --> tests/server_state/type_names.rs:5:1
    |
 5  | #[server_state]
-   | -^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^
    = note: this error originates in the attribute macro `server_state` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
rustc 1.65 minorly changed how spans are reported so the cli output has changed and most be updated